### PR TITLE
Add mirror judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ u want sending items via java jsonrpc client? turn to one java example: [jsonrpc
         - maxConns: 连接池相关配置，最大连接数，建议保持默认
         - maxIdle: 连接池相关配置，最大空闲连接数，建议保持默认
         - replicas: 这是一致性hash算法需要的节点副本数量，建议不要变更，保持默认即可
-        - cluster: key-value形式的字典，表示后端的judge列表，其中key代表后端judge名字，value代表的是具体的ip:port
+        - cluster: key-value形式的字典，表示后端的judge列表，其中key代表后端judge名字，value代表的是具体的ip:port(多个地址 用逗号隔开, transfer会将同一份数据 发送至各个地址)
+
 
     graph
         - enable: true/false, 表示是否开启向graph发送数据

--- a/g/g.go
+++ b/g/g.go
@@ -13,9 +13,10 @@ import (
 // 0.0.10: use more efficient proc & sema, rm conn_pool status log
 // 0.0.11: fix bug: all graphs' traffic delined when one graph broken down, modify retry interval
 // 0.0.14: support sending multi copies to graph node, align ts for judge, add filter
+// 0.0.15: support sending multi copies to judge node, useful for migrating step by step
 
 const (
-	VERSION      = "0.0.14"
+	VERSION      = "0.0.15"
 	GAUGE        = "GAUGE"
 	COUNTER      = "COUNTER"
 	DERIVE       = "DERIVE"

--- a/g/git.go
+++ b/g/git.go
@@ -1,4 +1,4 @@
 package g
 const (
-    COMMIT = "dfe28c5"
+    COMMIT = "190a7eb"
 )

--- a/g/git.go
+++ b/g/git.go
@@ -1,5 +1,4 @@
 package g
-
 const (
-	COMMIT = "43cbd02"
+    COMMIT = "df0fc3e"
 )

--- a/g/git.go
+++ b/g/git.go
@@ -1,4 +1,5 @@
 package g
+
 const (
-    COMMIT = "190a7eb"
+	COMMIT = "43cbd02"
 )

--- a/sender/conn_pools.go
+++ b/sender/conn_pools.go
@@ -10,8 +10,10 @@ func initConnPools() {
 	cfg := g.Config()
 
 	judgeInstances := nset.NewStringSet()
-	for _, instance := range cfg.Judge.Cluster {
-		judgeInstances.Add(instance)
+	for _, nitem := range cfg.Judge.Cluster2 {
+		for _, addr := range nitem.Addrs {
+			judgeInstances.Add(addr)
+		}
 	}
 	JudgeConnPools = cpool.CreateSafeRpcConnPools(cfg.Judge.MaxConns, cfg.Judge.MaxIdle,
 		cfg.Judge.ConnTimeout, cfg.Judge.CallTimeout, judgeInstances.ToSlice())

--- a/sender/send_queues.go
+++ b/sender/send_queues.go
@@ -7,9 +7,11 @@ import (
 
 func initSendQueues() {
 	cfg := g.Config()
-	for node, _ := range cfg.Judge.Cluster {
-		Q := nlist.NewSafeListLimited(DefaultSendQueueMaxSize)
-		JudgeQueues[node] = Q
+	for node, nitem := range cfg.Judge.Cluster2 {
+		for _, addr := range nitem.Addrs {
+			Q := nlist.NewSafeListLimited(DefaultSendQueueMaxSize)
+			JudgeQueues[node+addr] = Q
+		}
 	}
 
 	for node, nitem := range cfg.Graph.Cluster2 {

--- a/sender/send_tasks.go
+++ b/sender/send_tasks.go
@@ -88,10 +88,6 @@ func forward2JudgeTask(Q *list.SafeListLimited, node string, addr string, concur
 				time.Sleep(time.Millisecond * 10)
 			}
 
-			if g.Config().Debug {
-				log.Printf("send judge :%s data count: %v", addr, count)
-			}
-
 			// statistics
 			if !sendOk {
 				log.Printf("send judge %s:%s fail: %v", node, addr, err)


### PR DESCRIPTION
增加transfer发送judge的mirror功能，这个feature是在open-falcon集群灰度迁移到另外一个集群时有用，就像graph迁移一样； 
迁移计划： 先迁移数据(利用transfer graph migrate功能) -> 再迁移报警（这个pr中的功能） -> 最后将agent所有的hbs和transfer配置修改。
所以需要这样的功能，而且我看代码，是不是之前也有这种想法，最后摒弃了？ 
