### PR TITLE
增加 Transfer 对 statsd 的支持

### DIFF
--- a/cfg.example.json
+++ b/cfg.example.json
@@ -13,6 +13,12 @@
         "listen": "0.0.0.0:4444",
         "timeout": 3600
     },
+    "statsd": {
+        "enabled": true,
+        "listen": "0.0.0.0:8125",
+        "interval": 30,
+        "percent": 90
+    },
     "judge": {
         "enabled": true,
         "batch": 200,

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -2,10 +2,11 @@ package g
 
 import (
 	"encoding/json"
-	"github.com/toolkits/file"
 	"log"
 	"strings"
 	"sync"
+
+	"github.com/toolkits/file"
 )
 
 type HttpConfig struct {
@@ -22,6 +23,13 @@ type SocketConfig struct {
 	Enabled bool   `json:"enabled"`
 	Listen  string `json:"listen"`
 	Timeout int    `json:"timeout"`
+}
+
+type StatsdConfig struct {
+	Enabled  bool   `json:"enabled"`
+	Listen   string `json:"listen"`
+	Interval int64  `json:"interval"`
+	Percent  int    `json:"percent"`
 }
 
 type JudgeConfig struct {
@@ -72,6 +80,7 @@ type GlobalConfig struct {
 	Judge  *JudgeConfig  `json:"judge"`
 	Graph  *GraphConfig  `json:"graph"`
 	Tsdb   *TsdbConfig   `json:"tsdb"`
+	Statsd *StatsdConfig `json:"statsd"`
 }
 
 var (

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -25,7 +25,7 @@ type SocketConfig struct {
 	Timeout int    `json:"timeout"`
 }
 
-type StatsdConfig struct {
+type StatsDConfig struct {
 	Enabled  bool   `json:"enabled"`
 	Listen   string `json:"listen"`
 	Interval int64  `json:"interval"`
@@ -80,7 +80,7 @@ type GlobalConfig struct {
 	Judge  *JudgeConfig  `json:"judge"`
 	Graph  *GraphConfig  `json:"graph"`
 	Tsdb   *TsdbConfig   `json:"tsdb"`
-	Statsd *StatsdConfig `json:"statsd"`
+	StatsD *StatsDConfig `json:"statsd"`
 }
 
 var (

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -3,9 +3,11 @@ package receiver
 import (
 	"github.com/open-falcon/transfer/receiver/rpc"
 	"github.com/open-falcon/transfer/receiver/socket"
+	"github.com/open-falcon/transfer/receiver/statsd"
 )
 
 func Start() {
 	go rpc.StartRpc()
 	go socket.StartSocket()
+	go statsd.StartStatsD()
 }

--- a/receiver/statsd/statsd.go
+++ b/receiver/statsd/statsd.go
@@ -1,0 +1,41 @@
+package statsd
+
+import (
+	"bytes"
+	"log"
+	"net"
+
+	"github.com/open-falcon/transfer/g"
+)
+
+func StartStatsD() {
+	if !g.Config().StatsD.Enabled {
+		return
+	}
+
+	addr := g.Config().StatsD.Listen
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		log.Fatalf("net.ResolveUDPAddr fail: %s", err)
+	}
+
+	listener, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		log.Fatalf("listen %s fail: %s", addr, err)
+	} else {
+		log.Println("statsd listening", addr)
+	}
+
+	defer listener.Close()
+	go calc()
+
+	for {
+		message := make([]byte, 512)
+		n, remaddr, error := listener.ReadFrom(message)
+		if error != nil {
+			continue
+		}
+		buf := bytes.NewBuffer(message[0:n])
+		go handleMessage(listener, remaddr, buf)
+	}
+}

--- a/receiver/statsd/statsd_proxy.go
+++ b/receiver/statsd/statsd_proxy.go
@@ -1,0 +1,96 @@
+package statsd
+
+import (
+	"bytes"
+	"net"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/deckarep/golang-set"
+	"github.com/open-falcon/transfer/g"
+)
+
+type Packet struct {
+	Bucket   string
+	Value    int
+	Modifier string
+	Sampling float32
+}
+
+const (
+	STATSD_GAUGE = "statsd.gauges"
+)
+
+var (
+	metrics  = make(chan Packet, 10000)
+	counters = make(map[string]float32)
+	timers   = make(map[string][]float32)
+	gauges   = make(map[string]int)
+	sets     = make(map[string]mapset.Set)
+)
+
+func transfer() {
+	//TODO 等讨论
+}
+
+func calc() {
+	t := time.NewTicker(time.Duration(g.Config().StatsD.Interval) * time.Second)
+	for {
+		select {
+		case <-t.C:
+			transfer()
+		case s := <-metrics:
+			switch s.Modifier {
+			case "ms":
+				_, ok := timers[s.Bucket]
+				if !ok {
+					timers[s.Bucket] = []float32{}
+				}
+				timers[s.Bucket] = append(timers[s.Bucket], float32(s.Value)*s.Sampling)
+			case "g":
+				gauges[s.Bucket] = s.Value
+			case "s":
+				_, ok := sets[s.Bucket]
+				if !ok {
+					sets[s.Bucket] = mapset.NewSet()
+				}
+				sets[s.Bucket].Add(s.Value)
+			case "c":
+				_, ok := counters[s.Bucket]
+				if !ok {
+					counters[s.Bucket] = 0
+				}
+				counters[s.Bucket] += float32(s.Value) * (1.0 / s.Sampling)
+			}
+		}
+	}
+}
+
+func handleMessage(conn *net.UDPConn, remaddr net.Addr, buf *bytes.Buffer) {
+	var packet Packet
+	var sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9\\-_\\.:\\|@]")
+	var packetRegexp = regexp.MustCompile("([a-zA-Z0-9_]+):([0-9]+|-[0-9]+)\\|(c|ms|g|s)(\\|@([0-9\\.]+))?")
+	s := sanitizeRegexp.ReplaceAllString(buf.String(), "")
+	for _, item := range packetRegexp.FindAllStringSubmatch(s, -1) {
+		value, err := strconv.Atoi(item[2])
+		if err != nil {
+			if item[3] == "ms" {
+				value = 0
+			} else {
+				value = 1
+			}
+		}
+
+		sampleRate, err := strconv.ParseFloat(item[5], 32)
+		if err != nil {
+			sampleRate = 1
+		}
+
+		packet.Bucket = item[1]
+		packet.Value = value
+		packet.Modifier = item[3]
+		packet.Sampling = float32(sampleRate)
+		metrics <- packet
+	}
+}


### PR DESCRIPTION
**并未完全实现，请勿合并，想和大家讨论下**

设计上
- 绑定 udp ---> 完成
- 解析 statsd 协议，进行统计 ---> 完成
- 达到 step 设定时间 flush 进 open-falcon ---> 未完成

问题
- statsd 没 endpoint 这个维度，open-falcon 的过滤分 endpoint, metric key, tag 3个，怎么整合
- step 30秒一次对 timer, counter 的影响
- 样本精度，是 float 还是 int
- 对 statsd 协议一些 confusing 的地方，比如 timer 的 step 和 counter 的 step 有何不同

彩蛋

目前发现 model 里面并未实现闭源的 model.TsdbItem 对象，因此这个 transfer 是没法编译的
