### PR TITLE
sort node before added consistent hashing

### DIFF
--- a/sender/node_rings.go
+++ b/sender/node_rings.go
@@ -1,6 +1,8 @@
 package sender
 
 import (
+	"sort"
+
 	"github.com/open-falcon/transfer/g"
 	"github.com/toolkits/consistent"
 )
@@ -14,14 +16,15 @@ func initNodeRings() {
 
 // TODO 考虑放到公共组件库,或utils库
 func KeysOfMap(m map[string]string) []string {
-	keys := make([]string, len(m))
+	keys := make(sort.StringSlice, len(m))
 	i := 0
 	for key, _ := range m {
 		keys[i] = key
 		i++
 	}
 
-	return keys
+	keys.Sort()
+	return []string(keys)
 }
 
 // 一致性哈希环,用于管理服务器节点.


### PR DESCRIPTION
一致性hash的server的配置都是走的map的方式。但是这样有一个问题：如果生成hash ring的时候有冲突，使用map的方式就会有问题，因为map的迭代顺序是不确定的。比如如果A和Bhash有冲突，有可能在transfer的时候先迭代A再迭代B，则最终以B为准，但是在query的时候先迭代B再迭代A，查询的时候以A为准。这样就会有实际落在B的机器数据，但是查询的时候去A查的问题。
### 相关的几个PR需要同时合并
- [common](https://github.com/open-falcon/common/pull/4)
- [graph](https://github.com/open-falcon/graph/pull/21)
