### PR TITLE
支持数据写入到kafka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ _testmain.go
 *.log
 .idea
 .DS_Store
+_codesync
 /var
 /falcon-transfer*
 /cfg.json

--- a/cfg.example.json
+++ b/cfg.example.json
@@ -47,5 +47,15 @@
         "maxIdle": 32,
         "retry": 3,
         "address": "127.0.0.1:8088"
+    },
+    "kafka": {
+        "enabled": true,
+        "batch": 200,
+        "connTimeout": 1000,
+        "writeTimeout": 5000,
+        "maxConns": 5,
+        "retry": 3,
+        "address": "127.0.0.1:9092",
+        "topic": "test"
     }
 }

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -61,6 +61,17 @@ type TsdbConfig struct {
 	Address     string `json:"address"`
 }
 
+type KafkaConfig struct {
+	Enabled     bool   `json:"enabled"`
+	Batch       int    `json:"batch"`
+	ConnTimeout int    `json:"connTimeout"`
+	WriteTimeout int    `json:"writeTimeout"`
+	MaxConns    int    `json:"maxConns"`
+	MaxRetry    int    `json:"retry"`
+	Address     string `json:"address"`
+	Topic     string `json:"topic"`
+}
+
 type GlobalConfig struct {
 	Debug   bool          `json:"debug"`
 	MinStep int           `json:"minStep"` //最小周期,单位sec
@@ -70,6 +81,7 @@ type GlobalConfig struct {
 	Judge   *JudgeConfig  `json:"judge"`
 	Graph   *GraphConfig  `json:"graph"`
 	Tsdb    *TsdbConfig   `json:"tsdb"`
+	Kafka    *KafkaConfig   `json:"kafka"`
 }
 
 var (

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -25,19 +25,23 @@ var (
 
 	SendToJudgeCnt = nproc.NewSCounterQps("SendToJudgeCnt")
 	SendToTsdbCnt  = nproc.NewSCounterQps("SendToTsdbCnt")
+	SendToKafkaCnt  = nproc.NewSCounterQps("SendToKafkaCnt")
 	SendToGraphCnt = nproc.NewSCounterQps("SendToGraphCnt")
 
 	SendToJudgeDropCnt = nproc.NewSCounterQps("SendToJudgeDropCnt")
 	SendToTsdbDropCnt  = nproc.NewSCounterQps("SendToTsdbDropCnt")
+	SendToKafkaDropCnt  = nproc.NewSCounterQps("SendToKafkaDropCnt")
 	SendToGraphDropCnt = nproc.NewSCounterQps("SendToGraphDropCnt")
 
 	SendToJudgeFailCnt = nproc.NewSCounterQps("SendToJudgeFailCnt")
 	SendToTsdbFailCnt  = nproc.NewSCounterQps("SendToTsdbFailCnt")
+	SendToKafkaFailCnt  = nproc.NewSCounterQps("SendToKafkaFailCnt")
 	SendToGraphFailCnt = nproc.NewSCounterQps("SendToGraphFailCnt")
 
 	// 发送缓存大小
 	JudgeQueuesCnt = nproc.NewSCounterBase("JudgeSendCacheCnt")
 	TsdbQueuesCnt  = nproc.NewSCounterBase("TsdbSendCacheCnt")
+	KafkaQueuesCnt  = nproc.NewSCounterBase("KafkaSendCacheCnt")
 	GraphQueuesCnt = nproc.NewSCounterBase("GraphSendCacheCnt")
 )
 
@@ -57,21 +61,25 @@ func GetAll() []interface{} {
 	// send cnt
 	ret = append(ret, SendToJudgeCnt.Get())
 	ret = append(ret, SendToTsdbCnt.Get())
+	ret = append(ret, SendToKafkaCnt.Get())
 	ret = append(ret, SendToGraphCnt.Get())
 
 	// drop cnt
 	ret = append(ret, SendToJudgeDropCnt.Get())
 	ret = append(ret, SendToTsdbDropCnt.Get())
+	ret = append(ret, SendToKafkaDropCnt.Get())
 	ret = append(ret, SendToGraphDropCnt.Get())
 
 	// send fail cnt
 	ret = append(ret, SendToJudgeFailCnt.Get())
 	ret = append(ret, SendToTsdbFailCnt.Get())
+	ret = append(ret, SendToKafkaFailCnt.Get())
 	ret = append(ret, SendToGraphFailCnt.Get())
 
 	// cache cnt
 	ret = append(ret, JudgeQueuesCnt.Get())
 	ret = append(ret, TsdbQueuesCnt.Get())
+	ret = append(ret, KafkaQueuesCnt.Get())
 	ret = append(ret, GraphQueuesCnt.Get())
 
 	return ret

--- a/receiver/rpc/rpc_transfer.go
+++ b/receiver/rpc/rpc_transfer.go
@@ -145,6 +145,10 @@ func RecvMetricValues(args []*cmodel.MetricValue, reply *cmodel.TransferResponse
 	if cfg.Tsdb.Enabled {
 		sender.Push2TsdbSendQueue(items)
 	}
+	
+	if cfg.Kafka.Enabled {
+		sender.Push2KafkaSendQueue(items)
+	}
 
 	reply.Message = "ok"
 	reply.Total = len(args)

--- a/sender/conn_pool/conn_pool_manager.go
+++ b/sender/conn_pool/conn_pool_manager.go
@@ -192,7 +192,6 @@ func newTsdbConnPool(address string, maxConns int, maxIdle int, connTimeout int)
 }
 
 func newKafkaConnPool(address string, maxConns int, connTimeout int, writeTimeout int) sarama.SyncProducer {
-	//TODO kafka
 	kafka_config := sarama.NewConfig()
 	kafka_config.Net.MaxOpenRequests = maxConns
 	kafka_config.Net.DialTimeout = time.Duration(connTimeout) * time.Millisecond

--- a/sender/conn_pool/conn_pool_manager.go
+++ b/sender/conn_pool/conn_pool_manager.go
@@ -1,7 +1,10 @@
 package conn_pool
 
 import (
+	"errors"
 	"fmt"
+	"github.com/Shopify/sarama"
+	"log"
 	"net"
 	"net/rpc"
 	"sync"
@@ -188,6 +191,28 @@ func newTsdbConnPool(address string, maxConns int, maxIdle int, connTimeout int)
 	return pool
 }
 
+func newKafkaConnPool(address string, maxConns int, connTimeout int, writeTimeout int) sarama.SyncProducer {
+	//TODO kafka
+	kafka_config := sarama.NewConfig()
+	kafka_config.Net.MaxOpenRequests = maxConns
+	kafka_config.Net.DialTimeout = time.Duration(connTimeout) * time.Millisecond
+	kafka_config.Net.WriteTimeout = time.Duration(writeTimeout) * time.Millisecond
+	kafka_config.Producer.RequiredAcks = sarama.WaitForAll // ACK
+	//    kafka_config.Producer.Partitioner = sarama.NewRandomPartitioner  // 随机分区
+	kafka_config.Producer.Partitioner = sarama.NewManualPartitioner
+	kafka_config.Producer.Return.Successes = true // 返回true
+
+	kafka_client, err := sarama.NewSyncProducer([]string{address}, kafka_config)
+	if err != nil {
+		log.Fatalln("producer close, err:", err)
+		return kafka_client
+	}
+
+	//    defer kafka_client.Close()
+
+	return kafka_client
+}
+
 type TsdbConnPoolHelper struct {
 	p           *ConnPool
 	maxConns    int
@@ -195,6 +220,14 @@ type TsdbConnPoolHelper struct {
 	connTimeout int
 	callTimeout int
 	address     string
+}
+
+type KafkaConnPoolHelper struct {
+	p            sarama.SyncProducer
+	maxConns     int
+	connTimeout  int
+	writeTimeout int
+	address      string
 }
 
 func NewTsdbConnPoolHelper(address string, maxConns, maxIdle, connTimeout, callTimeout int) *TsdbConnPoolHelper {
@@ -206,6 +239,36 @@ func NewTsdbConnPoolHelper(address string, maxConns, maxIdle, connTimeout, callT
 		callTimeout: callTimeout,
 		address:     address,
 	}
+}
+
+func NewKafkaConnPoolHelper(address string, maxConns, connTimeout, writeTimeout int) *KafkaConnPoolHelper {
+	return &KafkaConnPoolHelper{
+		p:            newKafkaConnPool(address, maxConns, connTimeout, writeTimeout),
+		maxConns:     maxConns,
+		connTimeout:  connTimeout,
+		writeTimeout: writeTimeout,
+		address:      address,
+	}
+}
+
+func (this *KafkaConnPoolHelper) Send(value []byte, topic string, partition int32) (err error) {
+	msg := &sarama.ProducerMessage{}
+	msg.Topic = topic
+	msg.Partition = 0
+	msg.Value = sarama.StringEncoder(value)
+	partition, offset, err := this.p.SendMessage(msg)
+
+	if err == nil {
+		return nil
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err != nil {
+		return errors.New("Failed to produce message to kafka cluster.")
+	}
+	if partition != 0 {
+		return errors.New("Message should have been produced to partition 0!")
+	}
+	return errors.New(fmt.Sprintf("Produced message to partition %d with offset %d", partition, offset))
 }
 
 func (this *TsdbConnPoolHelper) Send(data []byte) (err error) {

--- a/sender/conn_pools.go
+++ b/sender/conn_pools.go
@@ -20,6 +20,11 @@ func initConnPools() {
 	if cfg.Tsdb.Enabled {
 		TsdbConnPoolHelper = cpool.NewTsdbConnPoolHelper(cfg.Tsdb.Address, cfg.Tsdb.MaxConns, cfg.Tsdb.MaxIdle, cfg.Tsdb.ConnTimeout, cfg.Tsdb.CallTimeout)
 	}
+	
+	// kafka
+	if cfg.Kafka.Enabled {
+		KafkaConnPoolHelper = cpool.NewKafkaConnPoolHelper(cfg.Kafka.Address, cfg.Kafka.MaxConns,cfg.Kafka.ConnTimeout, cfg.Kafka.WriteTimeout)
+	}
 
 	// graph
 	graphInstances := nset.NewSafeSet()
@@ -37,4 +42,5 @@ func DestroyConnPools() {
 	JudgeConnPools.Destroy()
 	GraphConnPools.Destroy()
 	TsdbConnPoolHelper.Destroy()
+//	KafkaConnPoolHelper.Destroy()
 }

--- a/sender/send_queues.go
+++ b/sender/send_queues.go
@@ -22,4 +22,8 @@ func initSendQueues() {
 	if cfg.Tsdb.Enabled {
 		TsdbQueue = nlist.NewSafeListLimited(DefaultSendQueueMaxSize)
 	}
+	
+		if cfg.Kafka.Enabled {
+		KafkaQueue = nlist.NewSafeListLimited(DefaultSendQueueMaxSize)
+	}
 }

--- a/sender/send_tasks.go
+++ b/sender/send_tasks.go
@@ -2,6 +2,7 @@ package sender
 
 import (
 	"bytes"
+	"encoding/json"
 	cmodel "github.com/open-falcon/common/model"
 	"github.com/open-falcon/transfer/g"
 	"github.com/open-falcon/transfer/proc"
@@ -23,6 +24,11 @@ func startSendTasks() {
 	judgeConcurrent := cfg.Judge.MaxConns
 	graphConcurrent := cfg.Graph.MaxConns
 	tsdbConcurrent := cfg.Tsdb.MaxConns
+	//	kafkaConcurrent := cfg.Kafka.MaxConns
+	//
+	//	if kafkaConcurrent < 1 {
+	//		kafkaConcurrent = 1
+	//	}
 
 	if tsdbConcurrent < 1 {
 		tsdbConcurrent = 1
@@ -51,6 +57,10 @@ func startSendTasks() {
 
 	if cfg.Tsdb.Enabled {
 		go forward2TsdbTask(tsdbConcurrent)
+	}
+
+	if cfg.Kafka.Enabled {
+		go forward2KafkaTask()
 	}
 }
 
@@ -143,6 +153,47 @@ func forward2GraphTask(Q *list.SafeListLimited, node string, addr string, concur
 				proc.SendToGraphCnt.IncrBy(int64(count))
 			}
 		}(addr, graphItems, count)
+	}
+}
+
+// Kafka定时任务, 将数据通过api发送到kafka
+func forward2KafkaTask() {
+	//TODO KAFKA
+	batch := g.Config().Kafka.Batch // 一次发送,最多batch条数据
+	retry := g.Config().Kafka.MaxRetry
+	topic := g.Config().Kafka.Topic
+
+	for {
+		items := KafkaQueue.PopBackBy(batch)
+		if len(items) == 0 {
+			time.Sleep(DefaultSendTaskSleepInterval)
+			continue
+		}
+		//  同步有限并发 进行发送
+		go func(itemList []interface{}) {
+			for i := 0; i < len(itemList); i++ {
+				for i := 0; i < retry; i++ {
+					msg, err := json.Marshal(itemList[i])
+					if err != nil {
+						log.Fatalln("data json decode err")
+						break
+					}
+					err = KafkaConnPoolHelper.Send(msg, topic, 0)
+					if err == nil {
+						proc.SendToKafkaCnt.IncrBy(int64(len(itemList)))
+						break
+					}
+
+					time.Sleep(100 * time.Millisecond)
+					if err != nil {
+						proc.SendToKafkaFailCnt.IncrBy(int64(len(itemList)))
+						log.Fatalln(err)
+					}
+
+				}
+			}
+		}(items)
+
 	}
 }
 

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -29,6 +29,7 @@ var (
 // 发送缓存队列
 // node -> queue_of_data
 var (
+    KafkaQueue   *nlist.SafeListLimited
 	TsdbQueue   *nlist.SafeListLimited
 	JudgeQueues = make(map[string]*nlist.SafeListLimited)
 	GraphQueues = make(map[string]*nlist.SafeListLimited)
@@ -39,6 +40,7 @@ var (
 var (
 	JudgeConnPools     *cpool.SafeRpcConnPools
 	TsdbConnPoolHelper *cpool.TsdbConnPoolHelper
+	KafkaConnPoolHelper *cpool.KafkaConnPoolHelper
 	GraphConnPools     *cpool.SafeRpcConnPools
 )
 
@@ -176,6 +178,17 @@ func Push2TsdbSendQueue(items []*cmodel.MetaData) {
 
 		if !isSuccess {
 			proc.SendToTsdbDropCnt.Incr()
+		}
+	}
+}
+
+// 将原始数据入到kafka发送缓存队列
+func Push2KafkaSendQueue(items []*cmodel.MetaData) {
+	for _, item := range items {
+		isSuccess := KafkaQueue.PushFront(item)
+
+		if !isSuccess {
+			proc.SendToKafkaDropCnt.Incr()
 		}
 	}
 }


### PR DESCRIPTION
为Transfer组件增加了将数据写入到kafka的支持，kafka本身作为数据队列本可以直接在接收后将数据放进去，但是为了代码可读性和一致性按照了transfer本身的处理流程走了一遍，同时不影响open-falcon原有功能，开启kafka可以在配置文件中指定，配置文件也按照原有格式书写，向原著致敬。该写入支持将是中国移动物联网开放平台全链路监控系统中的一个重要环节，代码本身亦符合工业级的稳定、安全、可维护等要求，可尽情使用。